### PR TITLE
EP-586: fixed nav collapse breakpoint

### DIFF
--- a/app/styles/ebf-design-system/_navbar.scss
+++ b/app/styles/ebf-design-system/_navbar.scss
@@ -81,7 +81,7 @@
   max-height: $spacer * 4;
 }
 
-@include media-breakpoint-down(sm) {
+@include media-breakpoint-down(md) {
   .navbar {
     max-height: none;
   }


### PR DESCRIPTION
Fixed navbar styles: now applying the required custom styles when smaller or equal than 'md' rather than 'sm'